### PR TITLE
fix: android builds and typescript declarations

### DIFF
--- a/android/src/main/java/com/reactnativescreencornerradius/ScreenCornerRadiusModule.kt
+++ b/android/src/main/java/com/reactnativescreencornerradius/ScreenCornerRadiusModule.kt
@@ -18,8 +18,6 @@ class ScreenCornerRadiusModule(reactContext: ReactApplicationContext) :
     return "ScreenCornerRadius"
   }
 
-  override fun hasConstants(): Boolean = true
-
   override fun getConstants(): MutableMap<String, Any?> {
     val cornerRadius = getCornerRadius()
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+declare module "react-native-screen-corner-radius" {
+	/**
+	 * The current device's screen's corner radius. May also be `0` if the corner radius couldn't be detected.
+	 */
+	export const ScreenCornerRadius: number;
+	/**
+	 * `true` if the screen has rounded corners, `false` otherwise.
+	 */
+	export const IsScreenRounded: boolean;
+}


### PR DESCRIPTION
This package currently breaks Android builds (see [this issue](https://github.com/mrousavy/react-native-screen-corner-radius/issues/7)). This pull request fixes Android builds.

Additionally, this pull request also adds an `index.d.ts` for type declarations (before, I had to manually create the declarations for this library).