### PR TITLE
fix: android gradle build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,8 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
@@ -52,7 +53,7 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
+  maven { url 'https://jitpack.io' }
   google()
 
   def found = false


### PR DESCRIPTION
Fixes this error during android build:

```sh
FAILURE: Build failed with an exception.

* Where:
Build file 'PROJECT_PATH/node_modules/react-native-screen-corner-radius/android/build.gradle' line: 7

* What went wrong:
A problem occurred evaluating project ':react-native-screen-corner-radius'.
> Could not find method jcenter() for arguments [] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.
```